### PR TITLE
Rename API arguments to work with current API

### DIFF
--- a/models/ForgeBox.cfc
+++ b/models/ForgeBox.cfc
@@ -95,6 +95,7 @@ component accessors="true"{
 	* @maxrows Used for pagination
 	* @startRow Used for pagination
 	* @typeSlug Filter by type
+	* @searchTerm Search by string
 	* 
 	* @results struct = { count:numeric, offset:numeric, results:array, totalRecords:numeric }
 	*/
@@ -102,14 +103,16 @@ component accessors="true"{
 		orderBy = "#this.ORDER.POPULAR#",
 		numeric maxrows = 0,
 		numeric startRow = 1,
-		typeslug=""
+		typeslug="",
+		searchTerm=""
 	){
 		var results = "";
 		var params = {
-			orderBY = arguments.orderby,
-			maxrows = arguments.maxrows,
-			startrow = arguments.startrow,
-			typeSlug = arguments.typeSlug	
+			orderBy = arguments.orderby,
+			max = arguments.maxrows,
+			offset = arguments.startrow,
+			typeSlug = arguments.typeSlug,
+			searchTerm = arguments.searchTerm
 		};
 		
 		// Invoke call


### PR DESCRIPTION
The SDK was using arguments that were invalid with the current API.  I also added searchTerm as a option.